### PR TITLE
Replace window with cell element

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -473,7 +473,7 @@ export class PSLGEditorView extends widgets.DOMWidgetView {
         this.svg.on('mousedown', mousedown)
             .on('mousemove', mousemove)
             .on('mouseup', mouseup);
-        d3.select(window)
+        d3.select(this.el)
             .on('keydown', keydown)
             .on('keyup', keyup);
         this.restart();


### PR DESCRIPTION
Don't catch keys in the whole window, just in the cell output.